### PR TITLE
Add Nvidia RTX4090 in gpus.csv

### DIFF
--- a/data/gpus.csv
+++ b/data/gpus.csv
@@ -30,6 +30,7 @@ TPUv3 Chip,tpu,283,45,90,160,320,128,average consumption - not TDP - from https:
 RTX 3080,gpu,320,29.77,29.77,NaN,NaN,10,https://www.techpowerup.com/gpu-specs/geforce-rtx-3080.c3621
 RTX 3080 TI,gpu,350,34.10,34.10,NaN,NaN,12,https://www.techpowerup.com/gpu-specs/geforce-rtx-3080-ti.c3735
 RTX 3090,gpu,350,35.58,35.58,NaN,NaN,24,https://www.techpowerup.com/gpu-specs/geforce-rtx-3090.c3622
+RTX 4090,gpu,300,82.6,82.6,NaN,NaN,24,https://images.nvidia.com/aem-dam/Solutions/Data-Center/l4/nvidia-ada-gpu-architecture-whitepaper-v2.1.pdf
 RTX A4000,gpu,140,19.17,19.17,NaN,NaN,16,https://www.techpowerup.com/gpu-specs/rtx-a4000.c3756
 RTX A5000,gpu,230,27.80,27.80,NaN,NaN,24,https://nvdam.widen.net/s/wrqrqt75vh/nvidia-rtx-a5000-datasheet
 RTX A6000,gpu,300,38.71,38.71,NaN,NaN,48,https://www.techpowerup.com/gpu-specs/rtx-a6000.c3686


### PR DESCRIPTION
Hi,

thanks for the valuable work you've done here. I took the initiative to update the `gpus.csv`  file with Nvidia's RTX4090. It's fair to say that it's currently one of the most popular consumer GPUs overall, and among the few that can enable home computers for training and inference.

Regards,
Markos